### PR TITLE
fixes double class warnings

### DIFF
--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -674,6 +674,8 @@ under the License.
 								<excludes>
 									<!-- log4j 2 is bundled separately from the flink-dist jar -->
 									<exclude>org.apache.logging.log4j:*</exclude>
+									<exclude>org.apache.logging.log4j:*</exclude>
+									<exclude>ch.qos.logback:*</exclude>
 									<!-- Bundled separately so that users can easily switch between ZK 3.4/3.5-->
 									<exclude>org.apache.flink:flink-shaded-zookeeper-3</exclude>
 								</excludes>

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -165,11 +165,13 @@ under the License.
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
+			<scope>compile</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-core</artifactId>
+			<scope>compile</scope>
 		</dependency>
 
 		<!--

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -674,7 +674,6 @@ under the License.
 								<excludes>
 									<!-- log4j 2 is bundled separately from the flink-dist jar -->
 									<exclude>org.apache.logging.log4j:*</exclude>
-									<exclude>org.apache.logging.log4j:*</exclude>
 									<exclude>ch.qos.logback:*</exclude>
 									<!-- Bundled separately so that users can easily switch between ZK 3.4/3.5-->
 									<exclude>org.apache.flink:flink-shaded-zookeeper-3</exclude>


### PR DESCRIPTION
fixes these warnings
```
support@confident-kirch-master:~$ flink --version
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/pipedream/local/venv/deepfield-env/flink/lib/logback-classic-1.2.3.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/pipedream/local/venv/deepfield-env/flink/lib/flink-dist_2.12-1.11.2.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [ch.qos.logback.classic.util.ContextSelectorStaticBinder]
Version: 1.11.2, Commit ID: 1982ed4
```

after applying patch

```
support@spooky-demon-master:~$ flink --version
Version: 1.11.2, Commit ID: c5a701a
```
