### PR TITLE
DEFBE-4493 release-1.11.3-deepfield cherry-pick 1.11.2.2 commits

### DIFF
--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -157,28 +157,19 @@ under the License.
 			it easier for users to swap logging frameworks -->
 
 		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-slf4j-impl</artifactId>
+			<groupId>org.slf4j</groupId>
+			<artifactId>log4j-over-slf4j</artifactId>
 			<scope>compile</scope>
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-			<scope>compile</scope>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-			<scope>compile</scope>
-		</dependency>
-
-		<dependency>
-			<!-- API bridge between log4j 1 and 2; included for convenience -->
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-1.2-api</artifactId>
-			<scope>compile</scope>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-core</artifactId>
 		</dependency>
 
 		<!--

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -165,11 +165,13 @@ under the License.
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
+			<scope>compile</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-core</artifactId>
+			<scope>compile</scope>
 		</dependency>
 
 		<!--
@@ -672,6 +674,7 @@ under the License.
 								<excludes>
 									<!-- log4j 2 is bundled separately from the flink-dist jar -->
 									<exclude>org.apache.logging.log4j:*</exclude>
+									<exclude>ch.qos.logback:*</exclude>
 									<!-- Bundled separately so that users can easily switch between ZK 3.4/3.5-->
 									<exclude>org.apache.flink:flink-shaded-zookeeper-3</exclude>
 								</excludes>

--- a/flink-dist/src/main/assemblies/bin.xml
+++ b/flink-dist/src/main/assemblies/bin.xml
@@ -38,10 +38,9 @@ under the License.
 			<useTransitiveFiltering>true</useTransitiveFiltering>
 
 			<includes>
-				<include>org.apache.logging.log4j:log4j-api</include>
-				<include>org.apache.logging.log4j:log4j-core</include>
-				<include>org.apache.logging.log4j:log4j-slf4j-impl</include>
-				<include>org.apache.logging.log4j:log4j-1.2-api</include>
+				<include>org.slf4j:log4j-over-slf4j</include>
+				<include>ch.qos.logback:logback-classic</include>
+				<include>ch.qos.logback:logback-core</include>
 			</includes>
 		</dependencySet>
 		<dependencySet>

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/MergingWindowSet.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/MergingWindowSet.java
@@ -218,7 +218,9 @@ public class MergingWindowSet<W extends Window> {
 
 		// the new window created a new, self-contained window without merging
 		if (mergeResults.isEmpty() || (resultWindow.equals(newWindow) && !mergedNewWindow)) {
-			this.mapping.put(resultWindow, resultWindow);
+			if (!this.mapping.containsKey(resultWindow)) {
+				this.mapping.put(resultWindow, resultWindow);
+			}
 		}
 
 		return resultWindow;

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,7 @@ under the License.
 		<akka.version>2.5.21</akka.version>
 		<java.version>1.8</java.version>
 		<slf4j.version>1.7.15</slf4j.version>
+		<logback.version>1.2.3</logback.version>
 		<log4j.version>2.12.1</log4j.version>
 		<!-- Overwrite default values from parent pom.
 			 Intellij is (sometimes?) using those values to choose target language level
@@ -448,6 +449,24 @@ under the License.
 				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-1.2-api</artifactId>
 				<version>${log4j.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.slf4j</groupId>
+				<artifactId>log4j-over-slf4j</artifactId>
+				<version>${slf4j.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>ch.qos.logback</groupId>
+				<artifactId>logback-classic</artifactId>
+				<version>${logback.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>ch.qos.logback</groupId>
+				<artifactId>logback-core</artifactId>
+				<version>${logback.version}</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
https://deepfield.atlassian.net/browse/DEFBE-4493

Porting Deepfield changes to 1.11.3 release of Flink:
- https://github.com/deepfield/flink/pull/3
- https://github.com/deepfield/flink/pull/4
- https://github.com/deepfield/flink/pull/5

I did not port Max's PR for the Zookeeper connection issue - https://github.com/deepfield/flink/pull/2 - Flink developers addressed the bug in 1.11.3 - please see the details in https://issues.apache.org/jira/browse/FLINK-19557 and https://github.com/apache/flink/pull/13725

### Running this branch on a 1-node 5.1 vlab:
```
support@flamboyant-diffie-master:~$ flink --version
Version: 1.11.3, Commit ID: 61da1d2
support@flamboyant-diffie-master:~$ flink list
Waiting for response...
------------------ Running/Restarting Jobs -------------------
19.04.2021 18:13:00 : c2b28f0c1650a4aa807df8019fdadba7 : Sentinel (RUNNING)
--------------------------------------------------------------
No scheduled jobs.
support@flamboyant-diffie-master:~$ date -u
Mon Apr 19 20:11:16 UTC 2021
support@flamboyant-diffie-master:~$ 
```
### 3-node 5.1 vlab with replay data
Untar:
```
sudo salt '*' cmd.run 'cd /home/support && tar zxvf flink-1.11.3-bin-scala_2.12.tgz'
```
`rm` 1.11.2:
```
sudo salt '*' cmd.run 'rm -fr /pipedream/local/venv/deepfield-env/flink/*'
```
Copy the patched 1.11.3:
```
sudo salt '*' cmd.run 'cp -R /home/support/flink-1.11.3/* /pipedream/local/venv/deepfield-env/flink/'
```
Restart Flink processes:
```
sudo salt -G roles:flink.jobmanager cmd.run 'systemctl restart flink-jobmanager.service'
sudo salt -G roles:worker cmd.run 'systemctl restart flink-taskmanager.service'
```

```
support@gifted-dhawan-master:~$ flink list
Waiting for response...
------------------ Running/Restarting Jobs -------------------
19.04.2021 21:25:36 : 8374bc882705aedaa939f473c8c86bc8 : Sentinel (RUNNING)
--------------------------------------------------------------
No scheduled jobs.
support@gifted-dhawan-master:~$ date -u
Mon Apr 19 21:35:00 UTC 2021
support@gifted-dhawan-master:~$ flink --version
Version: 1.11.3, Commit ID: 61da1d2
support@gifted-dhawan-master:~$ 
```
![image](https://user-images.githubusercontent.com/45573863/115307312-04c19200-a137-11eb-8381-ea85cf7b0da6.png)

CDN src/dst real-time query works:
![image](https://user-images.githubusercontent.com/45573863/115306441-d55e5580-a135-11eb-928c-d3240414fc9c.png)

OI Alert on CDN worked:
![image](https://user-images.githubusercontent.com/45573863/115308686-1c017f00-a139-11eb-8ef6-35cc49a6e1d4.png)

Flink has been running fine for ~15h:
```
support@gifted-dhawan-master:~$ flink list
Waiting for response...
------------------ Running/Restarting Jobs -------------------
19.04.2021 21:25:36 : 8374bc882705aedaa939f473c8c86bc8 : Sentinel (RUNNING)
--------------------------------------------------------------
No scheduled jobs.
support@gifted-dhawan-master:~$ date -u
Tue Apr 20 12:26:15 UTC 2021
support@gifted-dhawan-master:~$ sudo salt '*' cmd.run 'systemctl status flink-jobmanager.service | head -5'
gifted-dhawan-master:
    ● flink-jobmanager.service - Apache Flink Job Manager
       Loaded: loaded (/etc/systemd/system/flink-jobmanager.service; enabled; vendor preset: enabled)
       Active: active (running) since Mon 2021-04-19 21:25:04 UTC; 15h ago
         Docs: https://flink.apache.org/
      Process: 38259 ExecStop=/pipedream/local/venv/deepfield-env/flink/bin/jobmanager.sh stop (code=exited, status=0/SUCCESS)
worker02:
    ● flink-jobmanager.service - Apache Flink Job Manager
       Loaded: loaded (/etc/systemd/system/flink-jobmanager.service; enabled; vendor preset: enabled)
       Active: active (running) since Mon 2021-04-19 21:25:04 UTC; 15h ago
         Docs: https://flink.apache.org/
      Process: 67675 ExecStop=/pipedream/local/venv/deepfield-env/flink/bin/jobmanager.sh stop (code=exited, status=0/SUCCESS)
worker01:
    ● flink-jobmanager.service - Apache Flink Job Manager
       Loaded: loaded (/etc/systemd/system/flink-jobmanager.service; enabled; vendor preset: enabled)
       Active: active (running) since Mon 2021-04-19 21:25:04 UTC; 15h ago
         Docs: https://flink.apache.org/
      Process: 101787 ExecStop=/pipedream/local/venv/deepfield-env/flink/bin/jobmanager.sh stop (code=exited, status=0/SUCCESS)
support@gifted-dhawan-master:~$ sudo salt '*' cmd.run 'systemctl status flink-taskmanager.service | head -5'
gifted-dhawan-master:
    ● flink-taskmanager.service - Apache Flink Task Manager
       Loaded: loaded (/etc/systemd/system/flink-taskmanager.service; enabled; vendor preset: enabled)
       Active: active (running) since Mon 2021-04-19 21:25:29 UTC; 15h ago
         Docs: https://flink.apache.org/
      Process: 42700 ExecStop=/pipedream/local/venv/deepfield-env/flink/bin/taskmanager.sh stop (code=exited, status=0/SUCCESS)
worker02:
    ● flink-taskmanager.service - Apache Flink Task Manager
       Loaded: loaded (/etc/systemd/system/flink-taskmanager.service; enabled; vendor preset: enabled)
       Active: active (running) since Mon 2021-04-19 21:25:29 UTC; 15h ago
         Docs: https://flink.apache.org/
      Process: 70485 ExecStop=/pipedream/local/venv/deepfield-env/flink/bin/taskmanager.sh stop (code=exited, status=0/SUCCESS)
worker01:
    ● flink-taskmanager.service - Apache Flink Task Manager
       Loaded: loaded (/etc/systemd/system/flink-taskmanager.service; enabled; vendor preset: enabled)
       Active: active (running) since Mon 2021-04-19 21:25:29 UTC; 15h ago
         Docs: https://flink.apache.org/
      Process: 104951 ExecStop=/pipedream/local/venv/deepfield-env/flink/bin/taskmanager.sh stop (code=exited, status=0/SUCCESS)
support@gifted-dhawan-master:~$ 
```